### PR TITLE
Explicitly set the SSL version.

### DIFF
--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -105,6 +105,7 @@ module Postmark
       http.read_timeout = self.http_read_timeout
       http.open_timeout = self.http_open_timeout
       http.use_ssl = !!self.secure
+      http.ssl_version = :TLSv1
       http
     end
 


### PR DESCRIPTION
Prevents:

OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure