### PR TITLE
Explicitly set SSL/TLS version (with Ruby 1.8.7 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ rvm:
 - 2.2.2
 - jruby-19mode
 script: bundle exec rake spec
+before_install:
+  - gem update --system
+  - gem install bundler

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -105,6 +105,7 @@ module Postmark
       http.read_timeout = self.http_read_timeout
       http.open_timeout = self.http_open_timeout
       http.use_ssl = !!self.secure
+      http.ssl_version = :TLSv1
       http
     end
 

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -105,7 +105,7 @@ module Postmark
       http.read_timeout = self.http_read_timeout
       http.open_timeout = self.http_open_timeout
       http.use_ssl = !!self.secure
-      http.ssl_version = :TLSv1
+      http.ssl_version = :TLSv1 if http.respond_to?(:ssl_version=)
       http
     end
 

--- a/spec/unit/postmark/http_client_spec.rb
+++ b/spec/unit/postmark/http_client_spec.rb
@@ -40,6 +40,11 @@ describe Postmark::HttpClient do
     its(:path_prefix) { should eq '/' }
     its(:http_read_timeout) { should eq 15 }
     its(:http_open_timeout) { should eq 5 }
+
+    it 'uses TLS encryption', :skip_ruby_version => ['1.8.7'] do
+      http_client = subject.http
+      http_client.ssl_version.should == :TLSv1
+    end
   end
 
   context "when it is created with options" do


### PR DESCRIPTION
This is a modified version of #48 with addition of Ruby 1.8.7 support and a unit test. This PR should also have CI working, as secret parameters are not available for guest pull requests.