### PR TITLE
Feature/track links

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,10 @@
 = Changelog
 
+== Unreleased
+
+* Fix a bug when open tracking flag is set to false by default, when open tracking flag is not set by a user.
+* Added support for link tracking
+
 == 1.9.1
 
 * Fix a bug when port setting is not respected.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ client.deliver(from: 'sheldon@bigbangtheory.com',
 # => {:to=>"Leonard Hofstadter <leonard@bigbangtheory.com>", :submitted_at=>"2013-05-09T02:45:16.2059023-04:00", :message_id=>"b2b268e3-6a70-xxxx-b897-49c9eb8b1d2e", :error_code=>0, :message=>"OK"}
 ```
 
-## Sending an HTML message (with open tracking!)
+## Sending an HTML message with open tracking
 
 Simply pass an HTML document as html_body parameter to `#deliver`. You can also enable open tracking by setting `track_opens` to `true`.
 
@@ -78,6 +78,22 @@ client.deliver(from: 'sheldon@bigbangtheory.com',
                           'General rule of thumb is 36 adults or 70 ' \
                           'children.</p>',
                track_opens: true)
+# => {:to=>"Leonard Hofstadter <leonard@bigbangtheory.com>", :submitted_at=>"2013-05-09T02:51:08.8789433-04:00", :message_id=>"75c28987-564e-xxxx-b6eb-e8071873ac06", :error_code=>0, :message=>"OK"}
+```
+## Sending a message with link tracking
+
+To track visited links for emails you send, make sure to have links in html_body, text_body or both when passing them to `#deliver`. You need to enable link tracking by setting `track_links` parameter to one of the following options: `:html_only`, `:text_only`, `:html_and_text` or `:none`.
+Depending on parameter you set, link tracking will be enabled on plain text body, html body, both or none. Optionally you can also use string values as parameters 'HtmlOnly', 'TextOnly', 'HtmlAndText' or 'None'.
+
+``` ruby
+client.deliver(from: 'sheldon@bigbangtheory.com',
+               to: 'Leonard Hofstadter <leonard@bigbangtheory.com>',
+               subject: 'Re: What, to you, is a large crowd?',
+               html_body: '<p>Any group big enough to trample me to death. ' \
+                          'General <a href="http://www.example.com">rule of thumb</a> is 36 adults or 70 ' \
+                          'children.</p>',
+               text_body: 'Any group big enough to trample me to death. General rule of thumb is 36 adults or 70 children - http://www.example.com.',
+               track_links: :html_and_text)
 # => {:to=>"Leonard Hofstadter <leonard@bigbangtheory.com>", :submitted_at=>"2013-05-09T02:51:08.8789433-04:00", :message_id=>"75c28987-564e-xxxx-b6eb-e8071873ac06", :error_code=>0, :message=>"OK"}
 ```
 
@@ -398,6 +414,41 @@ end
 
 message.deliver
 # => #<Mail::Message:70355902117460, Multipart: false, Headers: <From: sheldon@bigbangtheory.com>, <To: leonard@bigbangtheory.com>, <Message-ID: 3a9370a2-6c24-4304-a03c-320a54cc59f7>, <Subject: Re: What, to you, is a large crowd?>, <Content-Type: text/html; charset=UTF-8>>
+```
+
+## Multipart message (with link tracking)
+
+Notice that we set `track_links` field to `:html_and_text`, to enable link tracking for both plain text and html parts for this message.
+
+``` ruby
+require 'rubygems'
+require 'postmark'
+require 'mail'
+require 'json'
+
+message = Mail.new do
+  from            'sheldon@bigbangtheory.com'
+  to              'Leonard Hofstadter <leonard@bigbangtheory.com>'
+  subject         'Re: What, to you, is a large crowd?'
+
+  text_part do
+    body          'Any group big enough to trample me to death. General rule of thumb is 36 adults or 70 children - http://www.example.com.'
+  end
+
+  html_part do
+    content_type  'text/html; charset=UTF-8'
+    body          '<p>Any group big enough to trample me to death. ' \
+                  'General <a href="http://www.example.com">rule of thumb</a> is 36 adults or 70 ' \
+                  'children.</p>'
+  end
+
+  track_links     :html_and_text
+
+  delivery_method Mail::Postmark, :api_token => 'your-postmark-api-token'
+end
+
+message.deliver
+# => #<Mail::Message:70355902117460, Multipart: true, Headers: <From: sheldon@bigbangtheory.com>, <To: leonard@bigbangtheory.com>, <Message-ID: 1a1370a1-6c21-4304-a03c-320a54cc59f7>, <Subject: Re: What, to you, is a large crowd?>, <Content-Type: multipart/alternative; boundary=--==_mimepart_58380d6029b17_20543fd48543fa14977a>, <TRACK-LINKS: HtmlAndText>>
 ```
 
 ## Message with attachments

--- a/lib/postmark/helpers/message_helper.rb
+++ b/lib/postmark/helpers/message_helper.rb
@@ -18,6 +18,10 @@ module Postmark
         message[:attachments] = attachments_to_postmark(message[:attachments])
       end
 
+      if message[:track_links]
+        message[:track_links] = ::Postmark::Inflector.to_postmark(message[:track_links])
+      end
+
       HashHelper.to_postmark(message)
     end
 

--- a/lib/postmark/mail_message_converter.rb
+++ b/lib/postmark/mail_message_converter.rb
@@ -30,7 +30,8 @@ module Postmark
         'Subject' => @message.subject,
         'Headers' => @message.export_headers,
         'Tag' => @message.tag.to_s,
-        'TrackOpens' => (cast_to_bool(@message.track_opens) unless @message.track_opens.empty?)
+        'TrackOpens' => (cast_to_bool(@message.track_opens) unless @message.track_opens.empty?),
+        'TrackLinks' => (@message.track_links unless @message.track_links.empty?)
       }
     end
 

--- a/lib/postmark/message_extensions/mail.rb
+++ b/lib/postmark/message_extensions/mail.rb
@@ -15,6 +15,15 @@ module Mail
       header['TAG'] = val
     end
 
+    def track_links(val = nil)
+      self.track_links=(val) unless val.nil?
+      header['TRACK-LINKS'].to_s
+    end
+
+    def track_links=(val)
+      header['TRACK-LINKS'] = ::Postmark::Inflector.to_postmark(val)
+    end
+
     def track_opens(val = nil)
       self.track_opens=(val) unless val.nil?
       header['TRACK-OPENS'].to_s
@@ -117,7 +126,7 @@ module Mail
         cc           bcc
         subject      tag
         attachment   to
-        track-opens
+        track-opens  track-links
       ]
     end
 

--- a/spec/unit/postmark/helpers/message_helper_spec.rb
+++ b/spec/unit/postmark/helpers/message_helper_spec.rb
@@ -80,46 +80,92 @@ describe Postmark::MessageHelper do
       message.merge(:track_opens => true)
     }
 
+    let(:message_with_open_tracking_false) {
+      message.merge(:track_opens => false)
+    }
+
     let(:postmark_message_with_open_tracking) {
       postmark_message.merge("TrackOpens" => true)
     }
 
+    let(:postmark_message_with_open_tracking_false) {
+      postmark_message.merge("TrackOpens" => false)
+    }
+
     it 'converts messages without custom headers and attachments correctly' do
-      subject.to_postmark(message).should == postmark_message
+      expect(subject.to_postmark(message)).to eq postmark_message
     end
 
     it 'converts messages with custom headers and without attachments correctly' do
-      subject.to_postmark(message_with_headers).should == postmark_message_with_headers
+      expect(subject.to_postmark(message_with_headers)).to eq postmark_message_with_headers
     end
 
     it 'converts messages with custom headers and attachments correctly' do
-      subject.to_postmark(message_with_headers_and_attachments).should == postmark_message_with_headers_and_attachments
+      expect(subject.to_postmark(message_with_headers_and_attachments)).to eq postmark_message_with_headers_and_attachments
     end
 
-    it 'includes open tracking flag when specified' do
-      expect(subject.to_postmark(message_with_open_tracking)).to eq(postmark_message_with_open_tracking)
+    context 'open tracking flag set' do
+
+      it 'true' do
+        expect(subject.to_postmark(message_with_open_tracking)).to eq(postmark_message_with_open_tracking)
+      end
+
+      it 'false' do
+        expect(subject.to_postmark(message_with_open_tracking_false)).to eq(postmark_message_with_open_tracking_false)
+      end
+
+    end
+
+    context 'link tracking flag set' do
+
+      let(:message_with_link_tracking_html) { message.merge(:track_links => :html_only) }
+      let(:message_with_link_tracking_text) { message.merge(:track_links => :text_only) }
+      let(:message_with_link_tracking_all) { message.merge(:track_links => :html_and_text) }
+      let(:message_with_link_tracking_none) { message.merge(:track_links => :none) }
+
+      let(:postmark_message_with_link_tracking_html) { postmark_message.merge("TrackLinks" => 'HtmlOnly') }
+      let(:postmark_message_with_link_tracking_text) { postmark_message.merge("TrackLinks" => 'TextOnly') }
+      let(:postmark_message_with_link_tracking_all) { postmark_message.merge("TrackLinks" => 'HtmlAndText') }
+      let(:postmark_message_with_link_tracking_none) { postmark_message.merge("TrackLinks" => 'None') }
+
+      it 'html' do
+        expect(subject.to_postmark(message_with_link_tracking_html)).to eq(postmark_message_with_link_tracking_html)
+      end
+
+      it 'text' do
+        expect(subject.to_postmark(message_with_link_tracking_text)).to eq(postmark_message_with_link_tracking_text)
+      end
+
+      it 'html and text' do
+        expect(subject.to_postmark(message_with_link_tracking_all)).to eq(postmark_message_with_link_tracking_all)
+      end
+
+      it 'none' do
+        expect(subject.to_postmark(message_with_link_tracking_none)).to eq(postmark_message_with_link_tracking_none)
+      end
+
     end
 
   end
 
   describe ".headers_to_postmark" do
     it 'converts headers to Postmark format' do
-      subject.headers_to_postmark(headers).should == postmark_headers
+      expect(subject.headers_to_postmark(headers)).to eq postmark_headers
     end
 
     it 'accepts single header as a non-array' do
-      subject.headers_to_postmark(headers.first).should == [postmark_headers.first]
+      expect(subject.headers_to_postmark(headers.first)).to eq [postmark_headers.first]
     end
   end
 
   describe ".attachments_to_postmark" do
 
     it 'converts attachments to Postmark format' do
-      subject.attachments_to_postmark(attachments).should == postmark_attachments
+      expect(subject.attachments_to_postmark(attachments)).to eq postmark_attachments
     end
 
     it 'accepts single attachment as a non-array' do
-      subject.attachments_to_postmark(attachments.first).should == [postmark_attachments.first]
+      expect(subject.attachments_to_postmark(attachments.first)).to eq [postmark_attachments.first]
     end
 
   end

--- a/spec/unit/postmark/mail_message_converter_spec.rb
+++ b/spec/unit/postmark/mail_message_converter_spec.rb
@@ -24,7 +24,7 @@ describe Postmark::MailMessageConverter do
     end
   end
 
-  let(:mail_message_with_tracking) do
+  let(:mail_message_with_open_tracking) do
     Mail.new do
       from          "sheldon@bigbangtheory.com"
       to            "lenard@bigbangtheory.com"
@@ -35,19 +35,7 @@ describe Postmark::MailMessageConverter do
     end
   end
 
-  let(:mail_message_with_tracking_set_variable) do
-    mail = mail_html_message
-    mail.track_opens=true
-    mail
-  end
-
-  let(:mail_message_with_tracking_disabled_set_variable) do
-    mail = mail_html_message
-    mail.track_opens=true
-    mail
-  end
-
-  let(:mail_message_with_tracking_disabled) do
+  let(:mail_message_with_open_tracking_disabled) do
     Mail.new do
       from          "sheldon@bigbangtheory.com"
       to            "lenard@bigbangtheory.com"
@@ -56,6 +44,42 @@ describe Postmark::MailMessageConverter do
       body          "<b>Hello Sheldon!</b>"
       track_opens   false
     end
+  end
+
+  let(:mail_message_with_open_tracking_set_variable) do
+    mail = mail_html_message
+    mail.track_opens=true
+    mail
+  end
+
+  let(:mail_message_with_open_tracking_disabled_set_variable) do
+    mail = mail_html_message
+    mail.track_opens=false
+    mail
+  end
+
+  let(:mail_message_with_link_tracking_all) do
+    mail = mail_html_message
+    mail.track_links   :html_and_text
+    mail
+  end
+
+  let(:mail_message_with_link_tracking_html) do
+    mail = mail_html_message
+    mail.track_links = :html_only
+    mail
+  end
+
+  let(:mail_message_with_link_tracking_text) do
+    mail = mail_html_message
+    mail.track_links = :text_only
+    mail
+  end
+
+  let(:mail_message_with_link_tracking_none) do
+    mail = mail_html_message
+    mail.track_links = :none
+    mail
   end
 
   let(:tagged_mail_message) do
@@ -205,46 +229,86 @@ describe Postmark::MailMessageConverter do
 
     context 'setup inside of mail' do
 
-      it 'is enabled' do
-        subject.new(mail_message_with_tracking).run.should == {
+      it 'enabled' do
+        expect(subject.new(mail_message_with_open_tracking).run).to eq ({
             "From" => "sheldon@bigbangtheory.com",
             "Subject" => "Hello!",
             "HtmlBody" => "<b>Hello Sheldon!</b>",
             "To" => "lenard@bigbangtheory.com",
-            "TrackOpens" => true}
+            "TrackOpens" => true})
       end
 
-      it 'is disabled' do
-        subject.new(mail_message_with_tracking_disabled).run.should == {
+      it 'disabled' do
+        expect(subject.new(mail_message_with_open_tracking_disabled).run).to eq ({
             "From" => "sheldon@bigbangtheory.com",
             "Subject" => "Hello!",
             "HtmlBody" => "<b>Hello Sheldon!</b>",
             "To" => "lenard@bigbangtheory.com",
-            "TrackOpens" => false}
+            "TrackOpens" => false})
       end
 
     end
 
     context 'setup with tracking variable' do
 
-      it 'is enabled' do
-        subject.new(mail_message_with_tracking_set_variable).run.should == {
+      it 'enabled' do
+        expect(subject.new(mail_message_with_open_tracking_set_variable).run).to eq ({
             "From" => "sheldon@bigbangtheory.com",
             "Subject" => "Hello!",
             "HtmlBody" => "<b>Hello Sheldon!</b>",
             "To" => "lenard@bigbangtheory.com",
-            "TrackOpens" => true}
+            "TrackOpens" => true})
       end
 
-      it 'is disabled' do
-        subject.new(mail_message_with_tracking_disabled_set_variable).run.should == {
+      it 'disabled' do
+        expect(subject.new(mail_message_with_open_tracking_disabled_set_variable).run).to eq ({
             "From" => "sheldon@bigbangtheory.com",
             "Subject" => "Hello!",
             "HtmlBody" => "<b>Hello Sheldon!</b>",
             "To" => "lenard@bigbangtheory.com",
-            "TrackOpens" => true}
+            "TrackOpens" => false})
       end
 
+    end
+
+  end
+
+  context 'link tracking' do
+
+    it 'html and text' do
+      expect(subject.new(mail_message_with_link_tracking_all).run).to eq ({
+          "From" => "sheldon@bigbangtheory.com",
+          "Subject" => "Hello!",
+          "HtmlBody" => "<b>Hello Sheldon!</b>",
+          "To" => "lenard@bigbangtheory.com",
+          "TrackLinks" => 'HtmlAndText'})
+    end
+
+    it 'html only' do
+      expect(subject.new(mail_message_with_link_tracking_html).run).to eq ({
+          "From" => "sheldon@bigbangtheory.com",
+          "Subject" => "Hello!",
+          "HtmlBody" => "<b>Hello Sheldon!</b>",
+          "To" => "lenard@bigbangtheory.com",
+          "TrackLinks" => 'HtmlOnly'})
+    end
+
+    it 'text only' do
+      expect(subject.new(mail_message_with_link_tracking_text).run).to eq ({
+          "From" => "sheldon@bigbangtheory.com",
+          "Subject" => "Hello!",
+          "HtmlBody" => "<b>Hello Sheldon!</b>",
+          "To" => "lenard@bigbangtheory.com",
+          "TrackLinks" => 'TextOnly'})
+    end
+
+    it 'none' do
+      expect(subject.new(mail_message_with_link_tracking_none).run).to eq ({
+          "From" => "sheldon@bigbangtheory.com",
+          "Subject" => "Hello!",
+          "HtmlBody" => "<b>Hello Sheldon!</b>",
+          "To" => "lenard@bigbangtheory.com",
+          "TrackLinks" => 'None'})
     end
 
   end

--- a/spec/unit/postmark/message_extensions/mail_spec.rb
+++ b/spec/unit/postmark/message_extensions/mail_spec.rb
@@ -15,7 +15,7 @@ describe Mail::Message do
   end
 
   let(:mail_html_message) do
-    mail = Mail.new do
+    Mail.new do
       from          "sheldon@bigbangtheory.com"
       to            "lenard@bigbangtheory.com"
       subject       "Hello!"
@@ -38,24 +38,102 @@ describe Mail::Message do
     mail_message.header['Tag'] = 'bogus-tag'
     mail_message.header['Attachment'] = 'anydatahere'
     mail_message.header['Allowed-Header'] = 'value'
+    mail_message.header['TRACK-OPENS'] = 'true'
+    mail_message.header['TRACK-LINKS'] = 'HtmlOnly'
     mail_message
+  end
+
+  describe '#tag' do
+
+    it 'value set on tag=' do
+      mail_message.tag='value'
+      expect(mail_message.tag).to eq 'value'
+    end
+
+    it 'value set on tag()' do
+      mail_message.tag('value')
+      expect(mail_message.tag).to eq 'value'
+    end
+
+  end
+
+  describe '#track_opens' do
+
+    context 'flag set on track_opens=' do
+
+      it 'true' do
+        mail_message.track_opens = true
+        expect(mail_message.track_opens).to eq 'true'
+      end
+
+      it 'false' do
+        mail_message.track_opens = false
+        expect(mail_message.track_opens).to eq 'false'
+      end
+
+      it 'not set' do
+        expect(mail_message.track_opens).to eq ''
+      end
+
+    end
+
+    context 'flag set on track_opens()' do
+
+      it 'true' do
+        mail_message.track_opens(true)
+        expect(mail_message.track_opens).to eq 'true'
+      end
+
+      it 'false' do
+        mail_message.track_opens(false)
+        expect(mail_message.track_opens).to eq 'false'
+      end
+
+    end
+
+  end
+
+  describe '#track_links' do
+
+    context 'flag set on track_links=' do
+
+      it 'set' do
+        mail_message.track_links=:html_only
+        expect(mail_message.track_links).to eq 'HtmlOnly'
+      end
+
+      it 'not set' do
+        expect(mail_message.track_links).to eq ''
+      end
+
+    end
+
+    context 'flag set on track_links()' do
+
+      it 'set' do
+        mail_message.track_links(:html_only)
+        expect(mail_message.track_links).to eq 'HtmlOnly'
+      end
+
+    end
+
   end
 
   describe "#html?" do
     it 'is true for html only email' do
-      mail_html_message.should be_html
+      expect(mail_html_message).to be_html
     end
   end
 
   describe "#body_html" do
     it 'returns html body if present' do
-      mail_html_message.body_html.should == "<b>Hello Sheldon!</b>"
+      expect(mail_html_message.body_html).to eq "<b>Hello Sheldon!</b>"
     end
   end
 
   describe "#body_text" do
     it 'returns text body if present' do
-      mail_message.body_text.should == "Hello Sheldon!"
+      expect(mail_message.body_text).to eq "Hello Sheldon!"
     end
   end
 
@@ -65,7 +143,7 @@ describe Mail::Message do
 
     it "stores attachments as an array" do
       mail_message.postmark_attachments = attached_hash
-      mail_message.instance_variable_get(:@_attachments).should include(attached_hash)
+      expect(mail_message.instance_variable_get(:@_attachments)).to include(attached_hash)
     end
 
     it "is deprecated" do
@@ -93,8 +171,8 @@ describe Mail::Message do
       mail_message.postmark_attachments = [attached_hash, attached_file]
       attachments = mail_message.export_attachments
 
-      attachments.should include(attached_hash)
-      attachments.should include(exported_file)
+      expect(attachments).to include(attached_hash)
+      expect(attachments).to include(exported_file)
     end
 
     it "is deprecated" do
@@ -116,13 +194,13 @@ describe Mail::Message do
 
       it "exports native attachments" do
         mail_message.attachments["face.jpeg"] = file_data
-        mail_message.export_attachments.should include(exported_data)
+        expect(mail_message.export_attachments).to include(exported_data)
       end
 
       it "still supports the deprecated attachments API" do
         mail_message.attachments["face.jpeg"] = file_data
         mail_message.postmark_attachments = exported_data
-        mail_message.export_attachments.should == [exported_data, exported_data]
+        expect(mail_message.export_attachments).to eq [exported_data, exported_data]
       end
 
     end
@@ -132,10 +210,11 @@ describe Mail::Message do
       it "exports the attachment with related content id" do
         mail_message.attachments.inline["face.jpeg"] = file_data
         attachments = mail_message.export_attachments
-        attachments.count.should_not be_zero
-        attachments.first.should include(exported_data)
-        attachments.first.should have_key('ContentID')
-        attachments.first['ContentID'].should start_with('cid:')
+
+        expect(attachments.count).to_not be_zero
+        expect(attachments.first).to include(exported_data)
+        expect(attachments.first).to have_key('ContentID')
+        expect(attachments.first['ContentID']).to start_with('cid:')
       end
 
     end
@@ -146,8 +225,8 @@ describe Mail::Message do
     let(:headers) { mail_message_with_bogus_headers.export_headers }
     let(:header_names) { headers.map { |h| h['Name'] } }
 
-    specify { header_names.should include('Allowed-Header') }
-    specify { header_names.count.should == 1 }
+    specify { expect(header_names).to include('Allowed-Header') }
+    specify { expect(header_names.count).to eq 1 }
   end
 
   describe "#to_postmark_hash" do


### PR DESCRIPTION
Hey @temochka 

while working on open tracking, I figured to add link tracking support. It's based on:

http://developer.postmarkapp.com/developer-api-server.html

flags supported are the ones mentioned in spec files written for it, I followed Ruby convention with symbols instead of strings which are used for the API calls ( :html_only, :none , etc).

Works in same way as tracking opens.

Let me know if these look ok, and I will see to update docs and add api calls too for new updates.