### PR TITLE
Fix CI failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,12 @@ source "http://rubygems.org"
 gemspec
 
 group :test do
-  gem 'rspec', '~> 2.14.0'
-  gem 'fakeweb'
+  gem 'rspec', '~> 3.7'
+  gem 'rspec-its', '~> 1.2'
+  gem 'fakeweb', :git => 'https://github.com/chrisk/fakeweb.git'
   gem 'fakeweb-matcher'
-  gem 'mime-types', '~> 1.25.1'
-  gem 'activesupport', '~> 3.2.0'
+  gem 'mime-types'
+  gem 'activesupport'
   gem 'i18n', '~> 0.6.0'
   gem 'yajl-ruby', '~> 1.0', :platforms => [:mingw, :mswin, :ruby]
 end

--- a/gemfiles/Gemfile.legacy
+++ b/gemfiles/Gemfile.legacy
@@ -6,10 +6,11 @@ gem 'rake', '< 11.0.0'
 gem 'json', '< 2.0.0'
 
 group :test do
-  gem 'rspec', '~> 2.14.0'
-  gem 'fakeweb'
+  gem 'rspec', '~> 3.7'
+  gem 'rspec-its', '~> 1.2'
+  gem 'fakeweb', :git => 'https://github.com/chrisk/fakeweb.git'
   gem 'fakeweb-matcher'
-  gem 'mime-types', '~> 1.25.1'
+  gem 'mime-types'
   gem 'activesupport', '~> 3.2.0'
   gem 'i18n', '~> 0.6.0'
   gem 'yajl-ruby', '~> 1.0', :platforms => [:mingw, :mswin, :ruby]

--- a/gemfiles/Gemfile.legacy
+++ b/gemfiles/Gemfile.legacy
@@ -10,7 +10,7 @@ group :test do
   gem 'rspec-its', '~> 1.2'
   gem 'fakeweb', :git => 'https://github.com/chrisk/fakeweb.git'
   gem 'fakeweb-matcher'
-  gem 'mime-types'
+  gem 'mime-types', '~> 1.25.1'
   gem 'activesupport', '~> 3.2.0'
   gem 'i18n', '~> 0.6.0'
   gem 'yajl-ruby', '~> 1.0', :platforms => [:mingw, :mswin, :ruby]

--- a/spec/integration/account_api_client_spec.rb
+++ b/spec/integration/account_api_client_spec.rb
@@ -33,7 +33,7 @@ describe 'Account API client usage' do
 
 
     # spf
-    expect(subject.verified_sender_spf?(new_sender[:id])).to be_true
+    expect(subject.verified_sender_spf?(new_sender[:id])).to be true
 
     # resend
     expect { subject.resend_sender_confirmation(new_sender[:id]) }.not_to raise_error
@@ -74,7 +74,7 @@ describe 'Account API client usage' do
     expect(updated_domain[:id]).to eq(new_domain[:id])
 
     # spf
-    expect(subject.verified_domain_spf?(new_domain[:id])).to be_true
+    expect(subject.verified_domain_spf?(new_domain[:id])).to be true
 
     # dkim
     expect { subject.rotate_domain_dkim(new_domain[:id]) }.

--- a/spec/integration/api_client_messages_spec.rb
+++ b/spec/integration/api_client_messages_spec.rb
@@ -91,14 +91,14 @@ describe "Sending Mail::Messages with Postmark::ApiClient" do
       api_client.deliver_messages(valid_messages)
 
       expect(valid_messages.all? { |m| m.message_id =~ postmark_message_id_format }).
-          to be_true
+          to be true
     end
 
     it 'updates delivered messages with related Postmark responses' do
       api_client.deliver_messages(valid_messages)
 
       expect(valid_messages.all? { |m| m.postmark_response["To"] == m.to[0] }).
-          to be_true
+          to be true
     end
 
     it 'returns as many responses as many messages were sent' do
@@ -114,7 +114,7 @@ describe "Sending Mail::Messages with Postmark::ApiClient" do
         api_client.deliver_messages(valid_messages)
 
         expect(valid_messages.all? { |m| m.postmark_response["To"] == m.to[0] }).
-            to be_true
+            to be true
       end
 
       it 'returns as many responses as many messages were sent' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require 'json'
 require 'fakeweb'
 require 'fakeweb_matcher'
 require 'rspec'
-require 'rspec/autorun'
+require 'rspec/its'
 require File.join(File.expand_path(File.dirname(__FILE__)), 'support', 'shared_examples.rb')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'support', 'helpers.rb')
 
@@ -22,6 +22,8 @@ end
 
 RSpec.configure do |config|
   include Postmark::RSpecHelpers
+
+  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 
 	config.filter_run_excluding :skip_for_platform => lambda { |platform|
     RUBY_PLATFORM.to_s =~ /^#{platform.to_s}/

--- a/spec/unit/postmark/account_api_client_spec.rb
+++ b/spec/unit/postmark/account_api_client_spec.rb
@@ -77,7 +77,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned list of senders' do
         allow(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_senders.map { |s| s.keys }.flatten
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
       it 'accepts offset and count options' do
@@ -132,7 +132,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_sender(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
     end
 
@@ -168,7 +168,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:post).and_return(response)
         keys = subject.create_sender(:foo => 'bar').keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
     end
 
@@ -205,7 +205,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:put).and_return(response)
         keys = subject.update_sender(42, :foo => 'bar').keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -233,7 +233,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:post).and_return(response)
         keys = subject.resend_sender_confirmation(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -255,12 +255,12 @@ describe Postmark::AccountApiClient do
 
       it 'returns false when SPFVerified field of the response is false' do
         allow(subject.http_client).to receive(:post).and_return(false_response)
-        expect(subject.verified_sender_spf?(42)).to be_false
+        expect(subject.verified_sender_spf?(42)).to be false
       end
 
       it 'returns true when SPFVerified field of the response is true' do
         allow(subject.http_client).to receive(:post).and_return(response)
-        expect(subject.verified_sender_spf?(42)).to be_true
+        expect(subject.verified_sender_spf?(42)).to be true
       end
 
     end
@@ -292,7 +292,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:post).and_return(response)
         keys = subject.request_new_sender_dkim(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -319,7 +319,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:delete).and_return(response)
         keys = subject.delete_sender(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -366,7 +366,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned list of domains' do
         allow(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_domains.map { |s| s.keys }.flatten
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
       it 'accepts offset and count options' do
@@ -408,7 +408,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_domain(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
     end
 
@@ -436,7 +436,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:post).and_return(response)
         keys = subject.create_domain(:foo => 'bar').keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
     end
 
@@ -465,7 +465,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:put).and_return(response)
         keys = subject.update_domain(42, :foo => 'bar').keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -483,12 +483,12 @@ describe Postmark::AccountApiClient do
 
       it 'returns false when SPFVerified field of the response is false' do
         allow(subject.http_client).to receive(:post).and_return(false_response)
-        expect(subject.verified_domain_spf?(42)).to be_false
+        expect(subject.verified_domain_spf?(42)).to be false
       end
 
       it 'returns true when SPFVerified field of the response is true' do
         allow(subject.http_client).to receive(:post).and_return(response)
-        expect(subject.verified_domain_spf?(42)).to be_true
+        expect(subject.verified_domain_spf?(42)).to be true
       end
 
     end
@@ -511,7 +511,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:post).and_return(response)
         keys = subject.rotate_domain_dkim(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -534,7 +534,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:delete).and_return(response)
         keys = subject.delete_sender(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -590,7 +590,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned list of servers' do
         allow(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_servers.map { |s| s.keys }.flatten
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
       it 'accepts offset and count options' do
@@ -631,7 +631,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:get).and_return(response)
         keys = subject.get_server(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -678,7 +678,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:post).and_return(response)
         keys = subject.create_server(:foo => 'bar').keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -720,7 +720,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:put).and_return(response)
         keys = subject.update_server(42, :foo => 'bar').keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end
@@ -743,7 +743,7 @@ describe Postmark::AccountApiClient do
       it 'formats the keys of returned response' do
         allow(subject.http_client).to receive(:delete).and_return(response)
         keys = subject.delete_server(42).keys
-        expect(keys.all? { |k| k.is_a?(Symbol) }).to be_true
+        expect(keys.all? { |k| k.is_a?(Symbol) }).to be true
       end
 
     end

--- a/spec/unit/postmark/bounce_spec.rb
+++ b/spec/unit/postmark/bounce_spec.rb
@@ -43,11 +43,11 @@ describe Postmark::Bounce do
     end
 
     it 'allows to activate the bounce' do
-      subject.can_activate?.should be_true
+      subject.can_activate?.should be true
     end
 
     it 'has an available dump' do
-      subject.dump_available?.should be_true
+      subject.dump_available?.should be true
     end
 
     its(:type) { should eq bounce_data[:type] }
@@ -69,11 +69,11 @@ describe Postmark::Bounce do
     end
 
     it 'allows to activate the bounce' do
-      subject.can_activate?.should be_true
+      subject.can_activate?.should be true
     end
 
     it 'has an available dump' do
-      subject.dump_available?.should be_true
+      subject.dump_available?.should be true
     end
 
     its(:type) { should eq bounce_data[:type] }
@@ -93,7 +93,7 @@ describe Postmark::Bounce do
     let(:api_client) { Postmark.api_client }
 
     it "calls #dump_bounce on shared api_client instance" do
-      Postmark.api_client.should_receive(:dump_bounce).with(bounce.id) { response }
+      expect(Postmark.api_client).to receive(:dump_bounce).with(bounce.id) { response }
       bounce.dump.should == bounce_body
     end
 
@@ -104,7 +104,7 @@ describe Postmark::Bounce do
     let(:api_client) { Postmark.api_client }
 
     it "calls #activate_bounce on shared api_client instance" do
-      api_client.should_receive(:activate_bounce).with(bounce.id) { bounce_data }
+      expect(api_client).to receive(:activate_bounce).with(bounce.id) { bounce_data }
       bounce.activate.should be_a Postmark::Bounce
     end
 
@@ -114,7 +114,7 @@ describe Postmark::Bounce do
     let(:api_client) { Postmark.api_client }
 
     it "calls #get_bounce on shared api_client instance" do
-      api_client.should_receive(:get_bounce).with(42) { bounce_data }
+      expect(api_client).to receive(:get_bounce).with(42) { bounce_data }
       Postmark::Bounce.find(42).should be_a Postmark::Bounce
     end
   end
@@ -125,8 +125,8 @@ describe Postmark::Bounce do
     let(:api_client) { Postmark.api_client }
 
     it "calls #get_bounces on shared api_client instance" do
-      api_client.should_receive(:get_bounces) { response }
-      Postmark::Bounce.all.should have(3).bounces
+      expect(api_client).to receive(:get_bounces) { response }
+      Postmark::Bounce.all.count.should eq(3)
     end
 
   end
@@ -137,7 +137,7 @@ describe Postmark::Bounce do
     let(:tags) { ["tag1", "tag2"] }
 
     it "calls #get_bounced_tags on shared api_client instance" do
-      api_client.should_receive(:get_bounced_tags) { tags }
+      expect(api_client).to receive(:get_bounced_tags) { tags }
       Postmark::Bounce.tags.should == tags
     end
   end

--- a/spec/unit/postmark/handlers/mail_spec.rb
+++ b/spec/unit/postmark/handlers/mail_spec.rb
@@ -15,19 +15,19 @@ describe Mail::Postmark do
   end
 
   it "wraps Postmark.send_through_postmark" do
-    Postmark::ApiClient.any_instance.should_receive(:deliver_message).with(message)
+    allow_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
     message.delivery_method Mail::Postmark
     message.deliver
   end
 
   it "returns self by default" do
-    Postmark::ApiClient.any_instance.should_receive(:deliver_message).with(message)
+    allow_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
     message.delivery_method Mail::Postmark
     message.deliver.should eq message
   end
 
   it "returns the actual response if :return_response setting is present" do
-    Postmark::ApiClient.any_instance.should_receive(:deliver_message).with(message)
+    allow_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
     message.delivery_method Mail::Postmark, :return_response => true
     message.deliver.should eq message
   end
@@ -39,13 +39,13 @@ describe Mail::Postmark do
 
   it 'uses provided API token' do
     message.delivery_method Mail::Postmark, :api_token => 'api-token'
-    Postmark::ApiClient.should_receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
+    expect(Postmark::ApiClient).to receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
     message.deliver
   end
 
   it 'uses API token provided as legacy api_key' do
     message.delivery_method Mail::Postmark, :api_key => 'api-token'
-    Postmark::ApiClient.should_receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
+    expect(Postmark::ApiClient).to receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
     message.deliver
   end
 end

--- a/spec/unit/postmark/http_client_spec.rb
+++ b/spec/unit/postmark/http_client_spec.rb
@@ -36,7 +36,7 @@ describe Postmark::HttpClient do
     its(:api_key) { should eq api_token }
     its(:host) { should eq 'api.postmarkapp.com' }
     its(:port) { should eq 443 }
-    its(:secure) { should be_true }
+    its(:secure) { should be true }
     its(:path_prefix) { should eq '/' }
     its(:http_read_timeout) { should eq 15 }
     its(:http_open_timeout) { should eq 5 }
@@ -128,8 +128,7 @@ describe Postmark::HttpClient do
     end
 
     it "raises a custom error when the request times out" do
-      subject.http.should_receive(:post).at_least(:once).
-                                             and_raise(Timeout::Error)
+      expect(subject.http).to receive(:post).at_least(:once).and_raise(Timeout::Error)
       expect { subject.post(target_path) }.to raise_error Postmark::TimeoutError
     end
 
@@ -170,7 +169,7 @@ describe Postmark::HttpClient do
     end
 
     it "raises a custom error when the request times out" do
-      subject.http.should_receive(:get).at_least(:once).and_raise(Timeout::Error)
+      expect(subject.http).to receive(:get).at_least(:once).and_raise(Timeout::Error)
       expect { subject.get(target_path) }.to raise_error Postmark::TimeoutError
     end
 
@@ -211,7 +210,7 @@ describe Postmark::HttpClient do
     end
 
     it "raises a custom error when the request times out" do
-      subject.http.should_receive(:put).at_least(:once).and_raise(Timeout::Error)
+      expect(subject.http).to receive(:put).at_least(:once).and_raise(Timeout::Error)
       expect { subject.put(target_path) }.to raise_error Postmark::TimeoutError
     end
 

--- a/spec/unit/postmark/message_extensions/mail_spec.rb
+++ b/spec/unit/postmark/message_extensions/mail_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mail::Message do
   before do
-    Kernel.stub(:warn)
+    allow(Kernel).to receive(:warn)
   end
 
   let(:mail_message) do
@@ -147,7 +147,7 @@ describe Mail::Message do
     end
 
     it "is deprecated" do
-      Kernel.should_receive(:warn).with(/deprecated/)
+      expect(Kernel).to receive(:warn).with(/deprecated/)
       mail_message.postmark_attachments = attached_hash
     end
   end
@@ -161,12 +161,12 @@ describe Mail::Message do
                            'Content' => ''} }
 
     before do
-      attached_file.stub(:is_a?) { |arg| arg == File ? true : false }
-      attached_file.stub(:path) { '/tmp/file.jpeg' }
+      allow(attached_file).to receive(:is_a?) { |arg| arg == File ? true : false }
+      allow(attached_file).to receive(:path) { '/tmp/file.jpeg' }
     end
 
     it "supports multiple attachment formats" do
-      IO.should_receive(:read).with("/tmp/file.jpeg").and_return("")
+      expect(IO).to receive(:read).with("/tmp/file.jpeg").and_return("")
 
       mail_message.postmark_attachments = [attached_hash, attached_file]
       attachments = mail_message.export_attachments
@@ -177,7 +177,7 @@ describe Mail::Message do
 
     it "is deprecated" do
       mail_message.postmark_attachments = attached_hash
-      Kernel.should_receive(:warn).with(/deprecated/)
+      expect(Kernel).to receive(:warn).with(/deprecated/)
       mail_message.postmark_attachments
     end
   end

--- a/spec/unit/postmark_spec.rb
+++ b/spec/unit/postmark_spec.rb
@@ -99,7 +99,7 @@ describe Postmark do
     context "when shared client instance does not exist" do
 
       it 'creates a new instance of Postmark::ApiClient' do
-        Postmark::ApiClient.should_receive(:new).
+        allow(Postmark::ApiClient).to receive(:new).
                             with(api_token,
                                  :secure => secure,
                                  :proxy_host => proxy_host,
@@ -127,12 +127,12 @@ describe Postmark do
     end
 
     it 'delegates the method to the shared api client instance' do
-      api_client.should_receive(:deliver_message).with(message)
+      allow(api_client).to receive(:deliver_message).with(message)
       subject.deliver_message(message)
     end
 
     it 'is also accessible as .send_through_postmark' do
-      api_client.should_receive(:deliver_message).with(message)
+      allow(api_client).to receive(:deliver_message).with(message)
       subject.send_through_postmark(message)
     end
   end
@@ -146,7 +146,7 @@ describe Postmark do
     end
 
     it 'delegates the method to the shared api client instance' do
-      api_client.should_receive(:deliver_messages).with(message)
+      allow(api_client).to receive(:deliver_messages).with(message)
       subject.deliver_messages(message)
     end
   end
@@ -159,7 +159,7 @@ describe Postmark do
     end
 
     it 'delegates the method to the shared api client instance' do
-      api_client.should_receive(:delivery_stats)
+      allow(api_client).to receive(:delivery_stats)
       subject.delivery_stats
     end
   end  


### PR DESCRIPTION
We’ve been observing CI failures due to RSpec/Rake conflicts. I looked at the issue and decided it was time to upgrade to RSpec 3. I decided against doubling down on the “new” `expect` syntax, so both `should` and `expect` are still enabled.

Also, Fakeweb is going to be an issue eventually, because it’s practically abandoned. Webmock is a good alternative, but we’d have to deprecate Ruby 1.8.7 to support it.