### PR TITLE
Do not capitalize headers

### DIFF
--- a/lib/postmark/message_extensions/mail.rb
+++ b/lib/postmark/message_extensions/mail.rb
@@ -78,7 +78,7 @@ module Mail
         self.header.fields.each do |field|
           key, value = field.name, field.value
           next if bogus_headers.include? key.downcase
-          name = key.split(/-/).map { |i| i.capitalize }.join('-')
+          name = key # key.split(/-/).map { |i| i.capitalize }.join('-')
 
           headers << { "Name" => name, "Value" => value }
         end


### PR DESCRIPTION
I found this commit on the internet, so it must be good, right? ;-)

Honestly, it's been a while since thought about fixing https://github.com/wildbit/postmark-gem/issues/47 internally, but with all the recent activity on this repo lately (thank you) now may be a good time to submit this.

We're running an old version of the postmark-gem, with this change, and it's working for us. Would love to see it, or any other solution, implemented. 

Thanks to @nickcanz, sorry that I can't find where we picked up the commit from now. ;-)