### PR TITLE
gemspec: Move rake to development dependencies

### DIFF
--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.7"
 
-  s.add_dependency "rake"
   s.add_dependency "json"
 
   s.add_development_dependency "mail"
+  s.add_development_dependency "rake"
 end


### PR DESCRIPTION
`rake` is not really a runtime dependency. The way it was previously phrased meant that all projects using this gem would include Rake as a _runtime_ dependency also, which increased their footprint unecessarily.

This PR moves it to development dependencies, which is where such gems are normally located. `bundle install` in this repo will still give you `rake`, but `bundle install` in dependers will not necessarily do so.