### PR TITLE
Add support for templated messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,3 @@ matrix:
       jdk: oraclejdk8 
       gemfile: gemfiles/Gemfile.legacy
 script: bundle exec rake spec
-before_install:
-  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ matrix:
       gemfile: gemfiles/Gemfile.legacy
 script: bundle exec rake spec
 before_install:
-  - gem update --system
   - gem install bundler

--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -99,12 +99,22 @@ module Postmark
     end
   end
 
+  class InvalidTemplateError < Error
+    attr_reader :postmark_response
+
+    def initialize(response)
+      @postmark_response = response
+      super('Failed to render the template. Please check #postmark_response on this error for details.')
+    end
+  end
+
   class TimeoutError < Error
     def retry?
       true
     end
   end
 
+  class MailAdapterError < Postmark::Error; end
   class UnknownMessageType < Error; end
   class InvalidApiKeyError < HttpServerError; end
   class InternalServerError < HttpServerError; end

--- a/lib/postmark/handlers/mail.rb
+++ b/lib/postmark/handlers/mail.rb
@@ -8,10 +8,11 @@ module Mail
     end
 
     def deliver!(mail)
-      settings = self.settings.dup
-      api_token = settings.delete(:api_token) || settings.delete(:api_key)
-      api_client = ::Postmark::ApiClient.new(api_token, settings)
-      response = api_client.deliver_message(mail)
+      response = if mail.templated?
+                   api_client.deliver_message_with_template(mail)
+                 else
+                   api_client.deliver_message(mail)
+                 end
 
       if settings[:return_response]
         response
@@ -20,5 +21,10 @@ module Mail
       end
     end
 
+    def api_client
+      settings = self.settings.dup
+      api_token = settings.delete(:api_token) || settings.delete(:api_key)
+      ::Postmark::ApiClient.new(api_token, settings)
+    end
   end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -28,3 +28,7 @@ RSpec::Matchers.define :a_postmark_json do |string|
     postmark_json?(actual)
   end
 end
+
+RSpec::Matchers.define :json_representation_of do |x|
+  match { |actual| Postmark::Json.decode(actual) == x }
+end

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -800,9 +800,9 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a POST request to /templates with the given attributes' do
-      expected_json = {'Name' => 'template name'}.to_json
-
-      expect(http_client).to receive(:post).with('templates', expected_json).and_return(response)
+      expect(http_client).to receive(:post).
+        with('templates', json_representation_of('Name' => 'template name')).
+        and_return(response)
 
       template = subject.create_template(:name => 'template name')
 
@@ -822,9 +822,9 @@ describe Postmark::ApiClient do
     end
 
     it 'performs a PUT request to /templates with the given attributes' do
-      expected_json = {'Name' => 'template name'}.to_json
-
-      expect(http_client).to receive(:put).with('templates/123', expected_json).and_return(response)
+      expect(http_client).to receive(:put).
+        with('templates/123', json_representation_of('Name' => 'template name')).
+        and_return(response)
 
       template = subject.update_template(123, :name => 'template name')
 
@@ -880,13 +880,12 @@ describe Postmark::ApiClient do
       end
 
       it 'performs a POST request and returns unmodified suggested template model' do
-        expected_template_json = {
-            'HtmlBody' => '{{MyName}}',
-            'TextBody' => '{{MyName}}',
-            'Subject' => '{{MyName}}'
-        }.to_json
-
-        expect(http_client).to receive(:post).with('templates/validate', expected_template_json).and_return(response)
+        expect(http_client).to receive(:post).
+          with('templates/validate',
+               json_representation_of('HtmlBody' => '{{MyName}}',
+                                      'TextBody' => '{{MyName}}',
+                                      'Subject' => '{{MyName}}')).
+          and_return(response)
 
         resp = subject.validate_template(:html_body => '{{MyName}}',
                                          :text_body => '{{MyName}}',
@@ -929,13 +928,11 @@ describe Postmark::ApiClient do
       end
 
       it 'performs a POST request and returns validation errors' do
-        expected_template_json = {
-            'HtmlBody' => '{{#each}}',
-            'TextBody' => '{{MyName}}',
-            'Subject' => '{{MyName}}'
-        }.to_json
-
-        expect(http_client).to receive(:post).with('templates/validate', expected_template_json).and_return(response)
+        expect(http_client).
+          to receive(:post).with('templates/validate',
+                                 json_representation_of('HtmlBody' => '{{#each}}',
+                                                        'TextBody' => '{{MyName}}',
+                                                        'Subject' => '{{MyName}}')).and_return(response)
 
         resp = subject.validate_template(:html_body => '{{#each}}',
                                          :text_body => '{{MyName}}',
@@ -952,12 +949,11 @@ describe Postmark::ApiClient do
 
   describe "#deliver_with_template" do
     let(:email) {Postmark::MessageHelper.to_postmark(message_hash)}
-    let(:email_json) {Postmark::Json.encode(email)}
     let(:http_client) {subject.http_client}
     let(:response) {{"MessageID" => 42}}
 
     it 'converts message hash to Postmark format and posts it to /email/withTemplate' do
-      expect(http_client).to receive(:post).with('email/withTemplate', email_json) {response}
+      expect(http_client).to receive(:post).with('email/withTemplate', json_representation_of(email)) {response}
       subject.deliver_with_template(message_hash)
     end
 
@@ -970,7 +966,7 @@ describe Postmark::ApiClient do
     end
 
     it 'converts response to ruby format' do
-      expect(http_client).to receive(:post).with('email/withTemplate', email_json) {response}
+      expect(http_client).to receive(:post).with('email/withTemplate', json_representation_of(email)) {response}
       r = subject.deliver_with_template(message_hash)
       r.should have_key(:message_id)
     end

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -10,6 +10,14 @@ describe Postmark::ApiClient do
       delivery_method Mail::Postmark
     end
   }
+  let(:templated_message) do
+    Mail.new do
+      from            "sheldon@bigbangtheory.com"
+      to              "lenard@bigbangtheory.com"
+      template_alias  "hello"
+      template_model  :name => "Sheldon"
+    end
+  end
 
   let(:api_client) {Postmark::ApiClient.new(api_token)}
   subject {api_client}
@@ -95,6 +103,11 @@ describe Postmark::ApiClient do
     let(:email_json) {Postmark::Json.encode(email)}
     let(:http_client) {subject.http_client}
 
+    it 'raises an error when given a templated message' do
+      expect { subject.deliver_message(templated_message) }.
+        to raise_error(ArgumentError, /Please use Postmark::ApiClient\#deliver_message_with_template/)
+    end
+
     it 'turns message into a JSON document and posts it to /email' do
       expect(http_client).to receive(:post).with('email', email_json)
       subject.deliver_message(message)
@@ -118,7 +131,41 @@ describe Postmark::ApiClient do
       allow(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
       expect {subject.deliver_message(message)}.to raise_error(Postmark::TimeoutError)
     end
+  end
 
+  describe "#deliver_message_with_template" do
+    let(:email) {templated_message.to_postmark_hash}
+    let(:email_json) {Postmark::Json.encode(email)}
+    let(:http_client) {subject.http_client}
+
+    it 'raises an error when given a non-templated message' do
+      expect { subject.deliver_message_with_template(message) }.
+        to raise_error(ArgumentError, 'Templated delivery requested, but the template is missing.')
+    end
+
+    it 'turns message into a JSON document and posts it to /email' do
+      expect(http_client).to receive(:post).with('email/withTemplate', email_json)
+      subject.deliver_message_with_template(templated_message)
+    end
+
+    it "retries 3 times" do
+      2.times do
+        expect(http_client).to receive(:post).and_raise(Postmark::InternalServerError)
+      end
+      expect(http_client).to receive(:post)
+      expect {subject.deliver_message_with_template(templated_message)}.not_to raise_error
+    end
+
+    it "retries on timeout" do
+      expect(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
+      expect(http_client).to receive(:post)
+      expect {subject.deliver_message_with_template(templated_message)}.not_to raise_error
+    end
+
+    it "proxies errors" do
+      allow(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
+      expect {subject.deliver_message_with_template(templated_message)}.to raise_error(Postmark::TimeoutError)
+    end
   end
 
   describe "#deliver_messages" do
@@ -127,6 +174,11 @@ describe Postmark::ApiClient do
     let(:emails_json) {Postmark::Json.encode(emails)}
     let(:http_client) {subject.http_client}
     let(:response) {[{}, {}, {}]}
+
+    it 'raises an error when given a templated message' do
+      expect { subject.deliver_messages([templated_message]) }.
+        to raise_error(ArgumentError, /Please use Postmark::ApiClient\#deliver_messages_with_templates/)
+    end
 
     it 'turns array of messages into a JSON document and posts it to /email/batch' do
       expect(http_client).to receive(:post).with('email/batch', emails_json) {response}
@@ -146,7 +198,39 @@ describe Postmark::ApiClient do
       expect(http_client).to receive(:post) {response}
       expect {subject.deliver_messages([message, message, message])}.not_to raise_error
     end
+  end
 
+  describe "#deliver_messages_with_templates" do
+    let(:email) {templated_message.to_postmark_hash}
+    let(:emails) {[email, email, email]}
+    let(:emails_json) {Postmark::Json.encode(emails)}
+    let(:http_client) {subject.http_client}
+    let(:response) {[{}, {}, {}]}
+    let(:messages) { Array.new(3) { templated_message } }
+
+    it 'raises an error when given a templated message' do
+      expect { subject.deliver_messages_with_templates([message]) }.
+        to raise_error(ArgumentError, 'Templated delivery requested, but one or more messages lack templates.')
+    end
+
+    it 'turns array of messages into a JSON document and posts it to /email/batch' do
+      expect(http_client).to receive(:post).with('email/batchWithTemplates', emails_json) {response}
+      subject.deliver_messages_with_templates(messages)
+    end
+
+    it "should retry 3 times" do
+      2.times do
+        expect(http_client).to receive(:post).and_raise(Postmark::InternalServerError)
+      end
+      expect(http_client).to receive(:post) {response}
+      expect {subject.deliver_messages_with_templates(messages)}.not_to raise_error
+    end
+
+    it "should retry on timeout" do
+      expect(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
+      expect(http_client).to receive(:post) {response}
+      expect {subject.deliver_messages_with_templates(messages)}.not_to raise_error
+    end
   end
 
   describe "#delivery_stats" do

--- a/spec/unit/postmark/error_spec.rb
+++ b/spec/unit/postmark/error_spec.rb
@@ -106,6 +106,15 @@ describe(Postmark::ApiInputError) do
   end
 end
 
+describe Postmark::InvalidTemplateError do
+  subject(:error) { Postmark::InvalidTemplateError.new(:foo => 'bar') }
+
+  it 'is created with a response' do
+    expect(error.message).to start_with('Failed to render the template.')
+    expect(error.postmark_response).to eq(:foo => 'bar')
+  end
+end
+
 describe(Postmark::TimeoutError) do
   it { is_expected.to be_a(Postmark::Error) }
   specify { expect(subject.retry?).to be true }
@@ -126,6 +135,10 @@ describe(Postmark::InternalServerError) do
 end
 
 describe(Postmark::UnexpectedHttpResponseError) do
+  it { is_expected.to be_a(Postmark::Error) }
+end
+
+describe(Postmark::MailAdapterError) do
   it { is_expected.to be_a(Postmark::Error) }
 end
 

--- a/spec/unit/postmark/handlers/mail_spec.rb
+++ b/spec/unit/postmark/handlers/mail_spec.rb
@@ -10,42 +10,74 @@ describe Mail::Postmark do
     end
   end
 
+  before do
+    message.delivery_method Mail::Postmark
+  end
+
+  subject(:handler) { message.delivery_method }
+
   it "can be set as delivery_method" do
     message.delivery_method Mail::Postmark
+
+    is_expected.to be_a(Mail::Postmark)
   end
 
-  it "wraps Postmark.send_through_postmark" do
-    allow_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
-    message.delivery_method Mail::Postmark
-    message.deliver
+  describe '#deliver!' do
+    it "returns self by default" do
+      expect_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
+      message.deliver.should eq message
+    end
+
+    it "returns the actual response if :return_response setting is present" do
+      expect_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
+      message.delivery_method Mail::Postmark, :return_response => true
+      message.deliver.should eq message
+    end
+
+    it "allows setting the api token" do
+      message.delivery_method Mail::Postmark, :api_token => 'api-token'
+      message.delivery_method.settings[:api_token].should == 'api-token'
+    end
+
+    it 'uses provided API token' do
+      message.delivery_method Mail::Postmark, :api_token => 'api-token'
+      expect(Postmark::ApiClient).to receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
+      message.deliver
+    end
+
+    it 'uses API token provided as legacy api_key' do
+      message.delivery_method Mail::Postmark, :api_key => 'api-token'
+      expect(Postmark::ApiClient).to receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
+      message.deliver
+    end
+
+    context 'when sending a pre-rendered message' do
+      it "uses ApiClient#deliver_message to send the message" do
+        expect_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
+        message.deliver
+      end
+    end
+
+    context 'when sending a Postmark template' do
+      let(:message) do
+        Mail.new do
+          from            "sheldon@bigbangtheory.com"
+          to              "lenard@bigbangtheory.com"
+          template_alias  "hello"
+          template_model  :name => "Sheldon"
+        end
+      end
+
+      it 'uses ApiClient#deliver_message_with_template to send the message' do
+        expect_any_instance_of(Postmark::ApiClient).to receive(:deliver_message_with_template).with(message)
+        message.deliver
+      end
+    end
   end
 
-  it "returns self by default" do
-    allow_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
-    message.delivery_method Mail::Postmark
-    message.deliver.should eq message
-  end
+  describe '#api_client' do
+    subject { handler.api_client }
 
-  it "returns the actual response if :return_response setting is present" do
-    allow_any_instance_of(Postmark::ApiClient).to receive(:deliver_message).with(message)
-    message.delivery_method Mail::Postmark, :return_response => true
-    message.deliver.should eq message
-  end
-
-  it "allows setting the api token" do
-    message.delivery_method Mail::Postmark, :api_token => 'api-token'
-    message.delivery_method.settings[:api_token].should == 'api-token'
-  end
-
-  it 'uses provided API token' do
-    message.delivery_method Mail::Postmark, :api_token => 'api-token'
-    expect(Postmark::ApiClient).to receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
-    message.deliver
-  end
-
-  it 'uses API token provided as legacy api_key' do
-    message.delivery_method Mail::Postmark, :api_key => 'api-token'
-    expect(Postmark::ApiClient).to receive(:new).with('api-token', {}).and_return(double(:deliver_message => true))
-    message.deliver
+    it { is_expected.to be_a(Postmark::ApiClient) }
   end
 end

--- a/spec/unit/postmark/mail_message_converter_spec.rb
+++ b/spec/unit/postmark/mail_message_converter_spec.rb
@@ -164,6 +164,15 @@ describe Postmark::MailMessageConverter do
     end
   end
 
+  let(:templated_message) do
+    Mail.new do
+      from            "sheldon@bigbangtheory.com"
+      to              "lenard@bigbangtheory.com"
+      template_alias  "hello"
+      template_model  :name => "Sheldon"
+    end
+  end
+
   it 'converts plain text messages correctly' do
     subject.new(mail_message).run.should == {
         "From" => "sheldon@bigbangtheory.com",
@@ -223,6 +232,14 @@ describe Postmark::MailMessageConverter do
         "TextBody" => "Hello Sheldon!",
         "To" => "Leonard Hofstadter <leonard@bigbangtheory.com>",
         "ReplyTo" => 'Penny The Neighbor <penny@bigbangtheory.com>'}
+  end
+
+  it 'convertes templated messages correctly' do
+    expect(subject.new(templated_message).run).
+      to eq("From" => "sheldon@bigbangtheory.com",
+            "TemplateAlias" => "hello",
+            "TemplateModel" => { :name => "Sheldon" },
+            "To" => "lenard@bigbangtheory.com")
   end
 
   context 'open tracking' do

--- a/spec/unit/postmark/message_extensions/mail_spec.rb
+++ b/spec/unit/postmark/message_extensions/mail_spec.rb
@@ -328,7 +328,7 @@ describe Mail::Message do
             to receive(:get_template).with(message.template_alias).
             and_return(template_response)
           expect_any_instance_of(Postmark::ApiClient).
-            to receive(:validate_template).with(template_response.merge(test_render_model: model)).
+            to receive(:validate_template).with(template_response.merge(:test_render_model => model)).
             and_return(render_response)
         end
 

--- a/spec/unit/postmark/message_extensions/mail_spec.rb
+++ b/spec/unit/postmark/message_extensions/mail_spec.rb
@@ -24,6 +24,15 @@ describe Mail::Message do
     end
   end
 
+  let(:templated_message) do
+    Mail.new do
+      from           "sheldon@bigbangtheory.com"
+      to             "lenard@bigbangtheory.com"
+      template_alias "Hello!"
+      template_model :name => "Sheldon"
+    end
+  end
+
   let(:mail_message_with_bogus_headers) do
     mail_message.header['Return-Path'] = 'bounce@wildbit.com'
     mail_message.header['From'] = 'info@wildbit.com'
@@ -239,4 +248,109 @@ describe Mail::Message do
     # See mail_message_converter_spec.rb
   end
 
+  describe '#templated?' do
+    specify { expect(mail_message).to_not be_templated }
+    specify { expect(templated_message).to be_templated }
+  end
+
+  describe '#prerender' do
+    let(:model) { templated_message.template_model }
+    let(:model_text) { model[:name] }
+
+    let(:template_response) do
+      {
+        :html_body => '<html><body>{{ name }}</body></html>',
+        :text_body => '{{ name }}'
+      }
+    end
+
+    let(:successful_render_response) do
+      {
+        :all_content_is_valid => true,
+        :subject => {
+          :rendered_content => 'Subject'
+        },
+        :text_body => {
+          :rendered_content => model_text
+        },
+        :html_body => {
+          :rendered_content => "<html><body>#{model_text}</body></html>"
+        }
+      }
+    end
+
+    let(:failed_render_response) do
+      {
+        :all_content_is_valid => false,
+        :subject => {
+          :rendered_content => 'Subject'
+        },
+        :text_body => {
+          :rendered_content => model_text
+        },
+        :html_body => {
+          :rendered_content => nil,
+          :validation_errors => [
+            { :message => 'The syntax for this template is invalid.', :line => 1, :character_position => 1 }
+          ]
+        }
+      }
+    end
+
+    subject(:rendering) { message.prerender }
+
+    context 'when called on a non-templated message' do
+      let(:message) { mail_message }
+
+      it 'raises a Postmark::Error' do
+        expect { rendering }.to raise_error(Postmark::Error, /Cannot prerender/)
+      end
+    end
+
+    context 'when called on a templated message' do
+      let(:message) { templated_message }
+
+      before do
+        message.delivery_method delivery_method
+      end
+
+      context 'and using a non-Postmark delivery method' do
+        let(:delivery_method) { Mail::SMTP }
+
+        specify { expect { rendering }.to raise_error(Postmark::MailAdapterError) }
+      end
+
+      context 'and using a Postmark delivery method' do
+        let(:delivery_method) { Mail::Postmark }
+
+        before do
+          expect_any_instance_of(Postmark::ApiClient).
+            to receive(:get_template).with(message.template_alias).
+            and_return(template_response)
+          expect_any_instance_of(Postmark::ApiClient).
+            to receive(:validate_template).with(template_response.merge(test_render_model: model)).
+            and_return(render_response)
+        end
+
+        context 'and rendering succeeds' do
+          let(:render_response) { successful_render_response }
+
+          it 'sets HTML and Text parts to rendered values' do
+            expect { rendering }.
+              to change { message.subject }.to(render_response[:subject][:rendered_content]).
+              and change { message.body_text }.to(render_response[:text_body][:rendered_content]).
+              and change { message.body_html }.to(render_response[:html_body][:rendered_content])
+          end
+        end
+
+        context 'and rendering fails' do
+          let(:render_response) { failed_render_response }
+
+          it 'raises Postmark::InvalidTemplateError' do
+            expect { rendering }.to raise_error(Postmark::InvalidTemplateError)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
ActionMailer (and thus [postmark-rails](https://github.com/wildbit/postmark-rails)) is tightly coupled with the Ruby mail library. When it comes to supporting templated messages in Rails, unless we want to reinvent the entire `ActionMailer::Base` and related facilities (logging, interceptors, previews, etc.), it makes sense to squeeze templates into the existing framework, which is exactly what this PR does.