### PR TITLE
Update SSL version to TLSv1_2

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,9 @@
 = Changelog
 
+== Unreleased
+
+* Change SSL version from `TLSv1` to `TLSv1_2`
+
 == 1.17.0
 
 * Update sent email message properly and not altering it's Message-ID with Postmark unique message id.

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -100,7 +100,7 @@ module Postmark
       http.read_timeout = self.http_read_timeout
       http.open_timeout = self.http_open_timeout
       http.use_ssl = !!self.secure
-      http.ssl_version = :TLSv1 if http.respond_to?(:ssl_version=)
+      http.ssl_version = :TLSv1_2 if http.respond_to?(:ssl_version=)
       http
     end
   end

--- a/spec/unit/postmark/http_client_spec.rb
+++ b/spec/unit/postmark/http_client_spec.rb
@@ -43,7 +43,7 @@ describe Postmark::HttpClient do
 
     it 'uses TLS encryption', :skip_ruby_version => ['1.8.7'] do
       http_client = subject.http
-      expect(http_client.ssl_version).to eq :TLSv1
+      expect(http_client.ssl_version).to eq :TLSv1_2
     end
   end
 


### PR DESCRIPTION
Recently I got an email from Postmark saying that you guys are dropping TLSv1 support.

> ...
> <img width="543" alt="Screenshot 2020-01-15 at 00 14 37" src="https://user-images.githubusercontent.com/2538374/72379053-16460e00-372c-11ea-91b8-1245a04d8aaf.png">
> ...

And since in this gem the version is explicitly set to `TLSv1` it seems to me that we need to update it. 
I propose updating it to `TLSv1_2` because it's the minimal version that Ruby gems require anyway:
https://blog.rubygems.org/2018/02/24/tls-10-and-11-deprecation-notice.html