### PR TITLE
allow using custom ssl version v1.19.2

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,21 @@
 = Changelog
 
+== 1.19.2
+
+Allow possibility to change TLS version for HTTP client.
+
+== 1.19.1
+
+Bounce tags endoint removed, since it's no longer supported by API.
+
+== 1.19.0
+
+Webhooks management support is added.
+
+== 1.18.0
+
+Custom headers with any type of character casing is supported now.
+
 == 1.17.0
 
 * Update sent email message properly and not altering it's Message-ID with Postmark unique message id.

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -6,7 +6,9 @@ module Postmark
     attr_accessor :api_token
     attr_reader :http, :secure, :proxy_host, :proxy_port, :proxy_user,
                 :proxy_pass, :host, :port, :path_prefix,
-                :http_open_timeout, :http_read_timeout, :auth_header_name
+                :http_open_timeout, :http_read_timeout, :http_ssl_version,
+                :auth_header_name
+
     alias_method :api_key, :api_token
     alias_method :api_key=, :api_token=
 
@@ -16,7 +18,8 @@ module Postmark
       :secure => true,
       :path_prefix => '/',
       :http_read_timeout => 15,
-      :http_open_timeout => 5
+      :http_open_timeout => 5,
+      :http_ssl_version => :TLSv1
     }
 
     def initialize(api_token, options = {})
@@ -100,7 +103,7 @@ module Postmark
       http.read_timeout = self.http_read_timeout
       http.open_timeout = self.http_open_timeout
       http.use_ssl = !!self.secure
-      http.ssl_version = :TLSv1 if http.respond_to?(:ssl_version=)
+      http.ssl_version = self.http_ssl_version if http.respond_to?(:ssl_version=)
       http
     end
   end

--- a/lib/postmark/version.rb
+++ b/lib/postmark/version.rb
@@ -1,3 +1,3 @@
 module Postmark
-  VERSION = '1.19.1'
+  VERSION = '1.20.1'
 end

--- a/lib/postmark/version.rb
+++ b/lib/postmark/version.rb
@@ -1,3 +1,3 @@
 module Postmark
-  VERSION = '1.20.1'
+  VERSION = '1.19.2'
 end

--- a/spec/integration/api_client_resources_spec.rb
+++ b/spec/integration/api_client_resources_spec.rb
@@ -18,6 +18,7 @@ describe 'Accessing server resources using the API' do
     let(:unique_token) {rand(36 ** 32).to_s(36)}
 
     it 'can be used to manage tag triggers via the API' do
+      skip("Endpoint removed")
       trigger = api_client.create_trigger(:tags, :match_name => "gemtest_#{unique_token}", :track_opens => true)
       api_client.update_trigger(:tags, trigger[:id], :match_name => "pre_#{trigger[:match_name]}")
       updated = api_client.get_trigger(:tags, trigger[:id])

--- a/spec/unit/postmark/http_client_spec.rb
+++ b/spec/unit/postmark/http_client_spec.rb
@@ -29,6 +29,7 @@ describe Postmark::HttpClient do
     it { expect(subject).to respond_to(:path_prefix) }
     it { expect(subject).to respond_to(:http_open_timeout) }
     it { expect(subject).to respond_to(:http_read_timeout) }
+    it { expect(subject).to respond_to(:http_ssl_version) }
   end
 
   context "when it is created without options" do
@@ -41,7 +42,7 @@ describe Postmark::HttpClient do
     its(:http_read_timeout) { is_expected.to eq 15 }
     its(:http_open_timeout) { is_expected.to eq 5 }
 
-    it 'uses TLS encryption', :skip_ruby_version => ['1.8.7'] do
+    it 'use default TLS encryption', :skip_ruby_version => ['1.8.7'] do
       http_client = subject.http
       expect(http_client.ssl_version).to eq :TLSv1
     end
@@ -58,6 +59,7 @@ describe Postmark::HttpClient do
     let(:path_prefix) { "/provided/path/prefix" }
     let(:http_open_timeout) { 42 }
     let(:http_read_timeout) { 42 }
+    let(:http_ssl_version) { :TLSv1_2}
 
     subject { Postmark::HttpClient.new(api_token,
                                        :secure => secure,
@@ -69,7 +71,8 @@ describe Postmark::HttpClient do
                                        :port => port,
                                        :path_prefix => path_prefix,
                                        :http_open_timeout => http_open_timeout,
-                                       :http_read_timeout => http_read_timeout) }
+                                       :http_read_timeout => http_read_timeout,
+                                       :http_ssl_version => http_ssl_version) }
 
     its(:api_token) { is_expected.to eq api_token }
     its(:api_key) { is_expected.to eq api_token }
@@ -83,6 +86,7 @@ describe Postmark::HttpClient do
     its(:path_prefix) { is_expected.to eq path_prefix }
     its(:http_open_timeout) { is_expected.to eq http_open_timeout }
     its(:http_read_timeout) { is_expected.to eq http_read_timeout }
+    its(:http_ssl_version) { is_expected.to eq http_ssl_version }
 
     it 'uses port 80 for plain HTTP connections' do
       expect(Postmark::HttpClient.new(api_token, :secure => false).port).to eq(80)


### PR DESCRIPTION
Hey @nickhammond 

I added in the option to change tls version. 

Ruby 1.8.7 and 1.9.2 don't support out of the box ssl v1.2 so I left the default version 1. We can later see if we want to make default higher version, or even default to higher based on Ruby version.

Let me know what you think. I skipped trigger test since from now on it will fail. We can release that update you made first and then merge it to this branch.

Let me know what you think?