### PR TITLE
added suppressions endpoint and ability to set message stream when sending v1.19.2

### DIFF
--- a/lib/postmark/api_client.rb
+++ b/lib/postmark/api_client.rb
@@ -333,6 +333,33 @@ module Postmark
       format_response http_client.delete("webhooks/#{id}")
     end
 
+    def get_suppressions_dump(message_stream)
+      _, batch = load_batch("message-streams/#{message_stream}/suppressions/dump", 'Suppressions', {})
+      batch
+    end
+
+    def suppressions_dump(message_stream)
+      get_suppressions_dump(message_stream).each
+    end
+
+    def create_suppressions(message_stream, attributes = {})
+      suppressions = 'Suppressions'
+      data = serialize(suppressions => attributes.map { |e| {'EmailAddress' => e }})
+
+      _, batch = format_batch_response(http_client.post(
+          "message-streams/#{message_stream}/suppressions", data), suppressions)
+      batch
+    end
+
+    def delete_suppressions(message_stream, attributes = {})
+      suppressions = 'Suppressions'
+      data = serialize(suppressions => attributes.map { |e| {'EmailAddress' => e }})
+
+      _, batch = format_batch_response(http_client.post(
+          "message-streams/#{message_stream}/suppressions/delete", data), suppressions)
+      batch
+    end
+
     protected
 
     def in_batches(messages)

--- a/lib/postmark/api_client.rb
+++ b/lib/postmark/api_client.rb
@@ -346,8 +346,8 @@ module Postmark
       suppressions = 'Suppressions'
       data = serialize(suppressions => attributes.map { |e| {'EmailAddress' => e }})
 
-      _, batch = format_batch_response(http_client.post(
-          "message-streams/#{message_stream}/suppressions", data), suppressions)
+      request = http_client.post("message-streams/#{message_stream}/suppressions", data)
+      _, batch = format_batch_response(request, suppressions)
       batch
     end
 
@@ -355,8 +355,8 @@ module Postmark
       suppressions = 'Suppressions'
       data = serialize(suppressions => attributes.map { |e| {'EmailAddress' => e }})
 
-      _, batch = format_batch_response(http_client.post(
-          "message-streams/#{message_stream}/suppressions/delete", data), suppressions)
+      request = http_client.post("message-streams/#{message_stream}/suppressions/delete", data)
+      _, batch = format_batch_response(request, suppressions)
       batch
     end
 

--- a/lib/postmark/client.rb
+++ b/lib/postmark/client.rb
@@ -64,10 +64,14 @@ module Postmark
       return {} unless response
 
       if response.kind_of? Array
-        response.map { |entry| Postmark::HashHelper.to_ruby(entry, compatible) }
+        response.map { |entry| format_response_entry(entry, compatible) }
       else
-        Postmark::HashHelper.to_ruby(response, compatible)
+        format_response_entry(response, compatible)
       end
+    end
+
+    def format_response_entry(entry, compatible)
+      Postmark::HashHelper.to_ruby(entry, compatible)
     end
 
     def get_resource_count(path, options = {})
@@ -86,6 +90,5 @@ module Postmark
     def format_batch_response(response, name)
       [response['TotalCount'], format_response(response[name])]
     end
-
   end
 end

--- a/lib/postmark/mail_message_converter.rb
+++ b/lib/postmark/mail_message_converter.rb
@@ -34,7 +34,8 @@ module Postmark
         'TrackLinks' => (::Postmark::Inflector.to_postmark(@message.track_links) unless @message.track_links.empty?),
         'Metadata' => @message.metadata,
         'TemplateAlias' => @message.template_alias,
-        'TemplateModel' => @message.template_model
+        'TemplateModel' => @message.template_model,
+        'MessageStream' => (@message.message_stream unless @message.message_stream.nil?)
       }
     end
 

--- a/lib/postmark/message_extensions/mail.rb
+++ b/lib/postmark/message_extensions/mail.rb
@@ -33,6 +33,15 @@ module Mail
       header['TRACK-OPENS'] = (!!val).to_s
     end
 
+    def message_stream=(val)
+      @message_stream=val
+    end
+
+    def message_stream(val = nil)
+      self.message_stream=(val) unless val.nil?
+      @message_stream
+    end
+
     def metadata(val = nil)
       if val
         @metadata = val

--- a/lib/postmark/version.rb
+++ b/lib/postmark/version.rb
@@ -1,3 +1,3 @@
 module Postmark
-  VERSION = '1.19.1'
+  VERSION = '1.19.2'
 end


### PR DESCRIPTION
Hey @nickcanz @tomazy 

added suppression endpoints, they are bit simplified compared to our API. You can see it by responses in: https://postmarkapp.com/developer/api/suppressions-api#suppression-dump

(Suppressions on top is removed, it matches closer to older endpoints)

Let me know your thoughts, what do you think?

```
client.create_suppressions('outbound', ['address+igor@example.com','address2+igor@example.com'])

> [{:email_address=>"nothing+igor@wildbit.com", :status=>"Suppressed"}]

client.delete_suppressions('outbound', ['address+igor@example.com', 'address2+igor@example.com'])

> [{:email_address=>"nothing+igor@wildbit.com", :status=>"Deleted"}]

client.get_suppressions_dump('outbound')

>  [{:email_address=>"bounce+@example.com", :suppression_reason=>"SpamComplaint", :origin=>"Recipient", :created_at=>"2020-01-16T14:25:17-05:00"}]
```