### PR TITLE
Following convention in message streams APIs

### DIFF
--- a/lib/postmark/api_client.rb
+++ b/lib/postmark/api_client.rb
@@ -329,7 +329,12 @@ module Postmark
     end
 
     def get_message_streams(options = {})
-      load_batch('message-streams', 'MessageStreams', options)
+      _, batch = load_batch('message-streams', 'MessageStreams', options)
+      batch
+    end
+
+    def message_streams(options = {})
+      find_each('message-streams', 'MessageStreams', options)
     end
 
     def get_message_stream(id)

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -37,6 +37,10 @@ module Postmark
       do_request { |client| client.put(url_path(path), data, headers) }
     end
 
+    def patch(path, data = '')
+      do_request { |client| client.patch(url_path(path), data, headers) }
+    end
+
     def get(path, query = {})
       do_request { |client| client.get(url_path(path + to_query_string(query)), headers) }
     end


### PR DESCRIPTION
@ibalosh could you please review this one? Note, that I haven't followed the existing convention for the suppression dump API as it differs from a typical GET request. Also, please mention the unresolved issues   that I missed during the other PR.

Also - what's your recommendation for the version number we should release this with? Should we just increment the patch number if we assume _get_message_streams_ is probably not used yet by anyone?