### PR TITLE
Allow `http_ssl_version: nil` to use system default

### DIFF
--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -21,6 +21,8 @@ module Postmark
       :http_open_timeout => 5,
       :http_ssl_version => :TLSv1
     }
+    
+    DEFAULT_SSL_VERSION = :DEFAULT_SSL_VERSION
 
     def initialize(api_token, options = {})
       @api_token = api_token
@@ -56,10 +58,18 @@ module Postmark
     protected
 
     def apply_options(options = {})
+      use_default_ssl_version = false
+      if options.key?(:http_ssl_version) && options[:http_ssl_version].nil?
+        use_default_ssl_version = true
+      end
+
       options = Hash[*options.select { |_, v| !v.nil? }.flatten]
       DEFAULTS.merge(options).each_pair do |name, value|
         instance_variable_set(:"@#{name}", value)
       end
+
+      @http_ssl_version = nil if use_default_ssl_version
+
       @port = options[:port] || (@secure ? 443 : 80)
     end
 

--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -21,8 +21,6 @@ module Postmark
       :http_open_timeout => 5,
       :http_ssl_version => :TLSv1
     }
-    
-    DEFAULT_SSL_VERSION = :DEFAULT_SSL_VERSION
 
     def initialize(api_token, options = {})
       @api_token = api_token


### PR DESCRIPTION
Otherwise we have to keep on top of SSL versions, and might get behind (stagnate) and end up using insecure communications. The option to use the system default is not possible when `nil` options are filtered out, so instead of removing that filter, this commit detects a nil option and overrides the default after the merge and instance_variable_set loop.

This is perhaps also a fix for #86.