### PR TITLE
Remove json gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,5 @@ group :test do
   gem 'fakeweb-matcher'
   gem 'mime-types'
   gem 'activesupport'
-  gem 'i18n', '~> 0.6.0'
   gem 'yajl-ruby', '~> 1.0', :platforms => [:mingw, :mswin, :ruby]
 end

--- a/postmark.gemspec
+++ b/postmark.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.7"
 
-  s.add_dependency "json"
-
   s.add_development_dependency "mail"
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
json is bundled as part of the Ruby stdlib. While active_support used to include json as part of their gemspec, this is no longer the case.

If for some reason a consumer of the postmark API wants to include the json gem in their bundle, they can do so, but consumers shouldn't be forced to include it.