### PR TITLE
Add specific error handling for invalid email addresses - issue #87

### DIFF
--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -31,9 +31,7 @@ module Postmark
       self.parsed_body = parsed_body
       self.status_code = status_code.to_i
       self.body = body
-      message = parsed_body.fetch(
-        'Message',
-        "The Postmark API responded with HTTP status #{status_code}.")
+      message = parsed_body.fetch('Message', "The Postmark API responded with HTTP status #{status_code}.")
 
       super(message)
     end

--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -30,6 +30,7 @@ module Postmark
     def initialize(status_code = 500, body = '', parsed_body = {})
       self.parsed_body = parsed_body
       self.status_code = status_code.to_i
+      self.body = body
       message = parsed_body.fetch(
         'Message',
         "The Postmark API responded with HTTP status #{status_code}.")
@@ -44,6 +45,7 @@ module Postmark
 
   class ApiInputError < HttpServerError
     INACTIVE_RECIPIENT = 406
+    INVALID_EMAIL_ADDRESS = 300
 
     attr_accessor :error_code
 
@@ -52,7 +54,9 @@ module Postmark
 
       case error_code
       when INACTIVE_RECIPIENT
-        InactiveRecipientError.new(INACTIVE_RECIPIENT, body, parsed_body)
+        InactiveRecipientError.new(error_code, body, parsed_body)
+      when INVALID_EMAIL_ADDRESS
+        InvalidEmailAddressError.new(error_code, body, parsed_body)
       else
         new(error_code, body, parsed_body)
       end
@@ -65,6 +69,12 @@ module Postmark
 
     def retry?
       false
+    end
+  end
+
+  class InvalidEmailAddressError < ApiInputError
+    def initialize(*args)
+      super
     end
   end
 

--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -70,11 +70,7 @@ module Postmark
     end
   end
 
-  class InvalidEmailAddressError < ApiInputError
-    def initialize(*args)
-      super
-    end
-  end
+  class InvalidEmailAddressError < ApiInputError; end
 
   class InactiveRecipientError < ApiInputError
     attr_reader :recipients

--- a/spec/unit/postmark/error_spec.rb
+++ b/spec/unit/postmark/error_spec.rb
@@ -97,6 +97,13 @@ describe(Postmark::ApiInputError) do
         it_behaves_like 'api input error'
       end
 
+      context '300' do
+        let(:code) {Postmark::ApiInputError::INVALID_EMAIL_ADDRESS}
+
+        it {is_expected.to be_a(Postmark::InvalidEmailAddressError)}
+        it_behaves_like 'api input error'
+      end
+
       context 'others' do
         let(:code) {'9999'}
 
@@ -140,6 +147,36 @@ end
 
 describe(Postmark::MailAdapterError) do
   it {is_expected.to be_a(Postmark::Error)}
+end
+
+describe(Postmark::InvalidEmailAddressError) do
+  describe '.new' do
+    let(:response) {{'Message' => message}}
+
+    subject do
+      Postmark::InvalidEmailAddressError.new(
+        Postmark::ApiInputError::INVALID_EMAIL_ADDRESS,
+        Postmark::Json.encode(response),
+        response)
+    end
+
+    let(:message) do
+      "{\"ErrorCode\":300,\"Message\":\"Error parsing 'To': Illegal email address " + \
+      "'ibalosh.testinggmail.com'. It must contain the '@' symbol.\"}"
+    end
+
+    it 'body is set' do
+      expect(subject.body).to eq(Postmark::Json.encode(response))
+    end
+
+    it 'parsed body is set' do
+      expect(subject.parsed_body).to eq(response)
+    end
+
+    it 'error code is set' do
+      expect(subject.error_code).to eq(Postmark::ApiInputError::INVALID_EMAIL_ADDRESS)
+    end
+  end
 end
 
 describe(Postmark::InactiveRecipientError) do
@@ -208,6 +245,18 @@ describe(Postmark::InactiveRecipientError) do
 
     it 'parses recipients from json payload' do
       expect(subject.recipients).to eq([address])
+    end
+
+    it 'body is set' do
+      expect(subject.body).to eq(Postmark::Json.encode(response))
+    end
+
+    it 'parsed body is set' do
+      expect(subject.parsed_body).to eq(response)
+    end
+
+    it 'error code is set' do
+      expect(subject.error_code).to eq(Postmark::ApiInputError::INACTIVE_RECIPIENT)
     end
   end
 end

--- a/spec/unit/postmark/error_spec.rb
+++ b/spec/unit/postmark/error_spec.rb
@@ -155,14 +155,11 @@ describe(Postmark::InvalidEmailAddressError) do
 
     subject do
       Postmark::InvalidEmailAddressError.new(
-        Postmark::ApiInputError::INVALID_EMAIL_ADDRESS,
-        Postmark::Json.encode(response),
-        response)
+        Postmark::ApiInputError::INVALID_EMAIL_ADDRESS, Postmark::Json.encode(response), response)
     end
 
     let(:message) do
-      "{\"ErrorCode\":300,\"Message\":\"Error parsing 'To': Illegal email address " + \
-      "'ibalosh.testinggmail.com'. It must contain the '@' symbol.\"}"
+      "Error parsing 'To': Illegal email address 'johne.xample.com'. It must contain the '@' symbol."
     end
 
     it 'body is set' do


### PR DESCRIPTION
Hi @tomazy 

could you check this one too? It's related to:

- Improve email address error handling https://github.com/wildbit/postmark-gem/issues/87

It's just an extension of old error handling Artem added way back. Added it separately just in case, since this one is extension compare to other one mainly being bugs. If this is approved though we could merge and release them all together.