### PR TITLE
Disabled automatic retries of failed requests

### DIFF
--- a/lib/postmark/client.rb
+++ b/lib/postmark/client.rb
@@ -6,7 +6,7 @@ module Postmark
 
     def initialize(api_token, options = {})
       options = options.dup
-      @max_retries = options.delete(:max_retries) || 3
+      @max_retries = options.delete(:max_retries) || 0
       @http_client = HttpClient.new(api_token, options)
     end
 

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -167,7 +167,7 @@ describe Postmark::ApiClient do
 
     context 'with retries' do
       let(:http_client) {api_client.http_client}
-      subject(:api_client) {Postmark::ApiClient.new(api_token, max_retries: 3)}
+      subject(:api_client) {Postmark::ApiClient.new(api_token, :max_retries => 3)}
 
       it 'retries 3 times' do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -71,7 +71,7 @@ describe Postmark::ApiClient do
 
     context 'with retries' do
       let(:http_client) {api_client.http_client}
-      subject(:api_client) {Postmark::ApiClient.new(api_token, max_retries: 3)}
+      subject(:api_client) {Postmark::ApiClient.new(api_token, :max_retries => 3)}
 
       it 'retries 3 times' do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)
@@ -125,7 +125,7 @@ describe Postmark::ApiClient do
 
     context 'with retries' do
       let(:http_client) {api_client.http_client}
-      subject(:api_client) {Postmark::ApiClient.new(api_token, max_retries: 3)}
+      subject(:api_client) {Postmark::ApiClient.new(api_token, :max_retries => 3)}
 
       it 'retries 3 times' do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)
@@ -210,7 +210,7 @@ describe Postmark::ApiClient do
 
     context 'with retries' do
       let(:http_client) {api_client.http_client}
-      subject(:api_client) {Postmark::ApiClient.new(api_token, max_retries: 3)}
+      subject(:api_client) {Postmark::ApiClient.new(api_token, :max_retries => 3)}
 
       it 'retries 3 times' do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)
@@ -249,7 +249,7 @@ describe Postmark::ApiClient do
 
     context 'with retries' do
       let(:http_client) {api_client.http_client}
-      subject(:api_client) {Postmark::ApiClient.new(api_token, max_retries: 3)}
+      subject(:api_client) {Postmark::ApiClient.new(api_token, :max_retries => 3)}
 
       it 'retries 3 times' do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)
@@ -909,7 +909,7 @@ describe Postmark::ApiClient do
 
     context 'with retries' do
       let(:http_client) {api_client.http_client}
-      subject(:api_client) {Postmark::ApiClient.new(api_token, max_retries: 3)}
+      subject(:api_client) {Postmark::ApiClient.new(api_token, :max_retries => 3)}
 
       it 'retries 3 times' do
         2.times { expect(http_client).to receive(:post).and_raise(Postmark::InternalServerError, 500) }

--- a/spec/unit/postmark/api_client_spec.rb
+++ b/spec/unit/postmark/api_client_spec.rb
@@ -78,6 +78,11 @@ describe Postmark::ApiClient do
         expect(http_client).to receive(:post) {response}
         expect {subject.deliver(message_hash)}.not_to raise_error
       end
+
+      it 'retry over the max_retries limit' do
+        expect(http_client).to receive(:post).thrice.and_raise(Postmark::InternalServerError)
+        expect {subject.deliver(message_hash)}.to raise_error(Postmark::InternalServerError)
+      end
     end
 
     it 'default retries - 0 times' do
@@ -133,6 +138,11 @@ describe Postmark::ApiClient do
         expect {subject.deliver_message(message)}.not_to raise_error
       end
 
+      it 'retry over the max_retries limit' do
+        expect(http_client).to receive(:post).thrice.and_raise(Postmark::InternalServerError)
+        expect {subject.deliver_message(message)}.to raise_error(Postmark::InternalServerError)
+      end
+
       it "retries on timeout" do
         expect(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
         expect(http_client).to receive(:post)
@@ -173,6 +183,11 @@ describe Postmark::ApiClient do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)
         expect(http_client).to receive(:post)
         expect {subject.deliver_message_with_template(templated_message)}.not_to raise_error
+      end
+
+      it 'retry over the max_retries limit' do
+        expect(http_client).to receive(:post).thrice.and_raise(Postmark::InternalServerError)
+        expect {subject.deliver_message_with_template(templated_message)}.to raise_error(Postmark::InternalServerError)
       end
 
       it "retries on timeout" do
@@ -218,6 +233,11 @@ describe Postmark::ApiClient do
         expect {subject.deliver_messages([message, message, message])}.not_to raise_error
       end
 
+      it 'retry over the max_retries limit' do
+        expect(http_client).to receive(:post).thrice.and_raise(Postmark::InternalServerError)
+        expect {subject.deliver_messages([message, message, message])}.to raise_error(Postmark::InternalServerError)
+      end
+
       it "retries on timeout" do
         expect(http_client).to receive(:post).and_raise(Postmark::TimeoutError)
         expect(http_client).to receive(:post) {response}
@@ -255,6 +275,11 @@ describe Postmark::ApiClient do
         expect(http_client).to receive(:post).twice.and_raise(Postmark::InternalServerError)
         expect(http_client).to receive(:post) {response}
         expect {subject.deliver_messages_with_templates(messages)}.not_to raise_error
+      end
+
+      it 'retry over the max_retries limit' do
+        expect(http_client).to receive(:post).thrice.and_raise(Postmark::InternalServerError)
+        expect {subject.deliver_messages_with_templates(messages)}.to raise_error(Postmark::InternalServerError)
       end
 
       it "retries on timeout" do
@@ -913,7 +938,6 @@ describe Postmark::ApiClient do
 
       it 'retries 3 times' do
         2.times { expect(http_client).to receive(:post).and_raise(Postmark::InternalServerError, 500) }
-
         expect(http_client).to receive(:post) {response}
         expect {subject.deliver_with_template(message_hash)}.not_to raise_error
       end


### PR DESCRIPTION
As per discussion we had, set retry to zero as default to avoid unexpected behavior when sending email. This leaves it still optional if someone wants to use it. 

We could add option to wiki, but I think we should leave it out for now, and just suggest to customers who don't care if message could be sent more times when their connection is unreliable.

Updated Rspec tests to mach it