### PR TITLE
Allow server token to come from mail header

### DIFF
--- a/lib/postmark/handlers/mail.rb
+++ b/lib/postmark/handlers/mail.rb
@@ -8,10 +8,15 @@ module Mail
     end
 
     def deliver!(mail)
+      server_token_index = mail.header_fields.index { |h| h.name == 'X-Postmark-Server-Token' }
+
+      # we delete the token header from the array so that it isn't sent with the email
+      server_token_from_header = server_token_index ? mail.header_fields.delete_at(server_token_index).value : nil
+
       response = if mail.templated?
-                   api_client.deliver_message_with_template(mail)
+                   api_client(server_token_from_header).deliver_message_with_template(mail)
                  else
-                   api_client.deliver_message(mail)
+                   api_client(server_token_from_header).deliver_message(mail)
                  end
 
       if settings[:return_response]
@@ -21,9 +26,10 @@ module Mail
       end
     end
 
-    def api_client
+    def api_client(server_token_from_header)
       settings = self.settings.dup
-      api_token = settings.delete(:api_token) || settings.delete(:api_key)
+      api_token = server_token_from_header || settings.delete(:api_token) || settings.delete(:api_key)
+
       ::Postmark::ApiClient.new(api_token, settings)
     end
   end

--- a/spec/unit/postmark/handlers/mail_spec.rb
+++ b/spec/unit/postmark/handlers/mail_spec.rb
@@ -58,6 +58,23 @@ describe Mail::Postmark do
       end
     end
 
+    context 'when providing mail headers' do
+      let(:message) do
+        Mail.new do
+          from            "sheldon@bigbangtheory.com"
+          to              "lenard@bigbangtheory.com"
+          template_alias  "hello"
+          template_model  :name => "Sheldon"
+          headers         { "X-Postmark-Server-Token'" => "not-secret-token" }
+        end
+      end
+
+      it 'uses the provided server token to send the message' do
+        expect(Postmark::ApiClient).to receive(:new).with('not-secret-token', {}).and_return(double(:deliver_message => true))
+        message.deliver
+      end
+    end
+
     context 'when sending a Postmark template' do
       let(:message) do
         Mail.new do


### PR DESCRIPTION
There's a bit of an issue in https://github.com/wildbit/postmark-rails which I tracked down to this repository.

The recommended way to set emails using ActionMailer and Postmark is given as follows:

```ruby
config.action_mailer.delivery_method = :postmark
config.action_mailer.postmark_settings = { api_token: Rails.application.credentials.postmark_api_token }
```

However, this doesn't work if you'd like to send an email for more than one server. In our specific use case, we have several Postmark servers set up to handle different production environments.

If you remove the `postmark_settings` configuration, you'll get this error:

```
InputError (No Account or Server API tokens were supplied in the HTTP headers. Please add a header for either X-Postmark-Server-Token or X-Postmark-Account-Token.):
/Users/gjtorikian/.gem/gems/postmark-1.22.0/lib/postmark/http_client.rb:78:in `handle_response'
/Users/gjtorikian/.gem/gems/postmark-1.22.0/lib/postmark/http_client.rb:92:in `block in do_request'
/Users/gjtorikian/.gem/gems/postmark-1.22.0/lib/postmark/http_client.rb:91:in `synchronize'
/Users/gjtorikian/.gem/gems/postmark-1.22.0/lib/postmark/http_client.rb:91:in `do_request'
/Users/gjtorikian/.gem/gems/postmark-1.22.0/lib/postmark/http_client.rb:32:in `post'
```

Great, that makes sense: an API token is missing.

But, if you try to attach this token through the mail headers, it doesn't work:

```ruby
class OurAppMailer < ApplicationMailer
  def outbound_customer_email
    @html_body = params[:html_body].html_safe
    @text_body = params[:text_body]
    headers['In-Reply-To'] = params[:in_reply_to_id]
    headers['X-Postmark-Server-Token'] = token

    mail(
      from: params[:from_address],
      to: params[:to_addresses],
      subject: params[:subject],
      reply_to: params[:reply_to]
    )
  end
end
```

Attempting to do this ☝️ results in the same error.  @ryden noted this at the bottom of https://github.com/wildbit/postmark-rails/issues/60#issuecomment-904490492. 

To solve this, I propose this PR: if the server token is provided, remove it from the mail headers and use it before trying to grab any tokens in the configuration settings. 