### PR TITLE
Parse recipients list for InvalidEmailAddressError as well

### DIFF
--- a/lib/postmark/error.rb
+++ b/lib/postmark/error.rb
@@ -70,17 +70,13 @@ module Postmark
     end
   end
 
-  class InvalidEmailAddressError < ApiInputError; end
-
-  class InactiveRecipientError < ApiInputError
+  class InvalidRecipientError < ApiInputError
     attr_reader :recipients
 
-    PATTERNS = [/^Found inactive addresses: (.+?)\.$/.freeze,
-                /these inactive addresses: (.+?)\. Inactive/.freeze,
-                /these inactive addresses: (.+?)\.?$/].freeze
+    PATTERNS = []
 
     def self.parse_recipients(message)
-      PATTERNS.each do |p|
+      self::PATTERNS.each do |p|
         _, recipients = p.match(message).to_a
         next unless recipients
         return recipients.split(', ')
@@ -101,6 +97,16 @@ module Postmark
 
       self.class.parse_recipients(parsed_body['Message'])
     end
+  end
+
+  class InactiveRecipientError < InvalidRecipientError
+    PATTERNS = [/^Found inactive addresses: (.+?)\.$/.freeze,
+                /these inactive addresses: (.+?)\. Inactive/.freeze,
+                /these inactive addresses: (.+?)\.?$/].freeze
+  end
+
+  class InvalidEmailAddressError < InvalidRecipientError
+    PATTERNS = [/in address '(.+?)'\.$/.freeze]
   end
 
   class InvalidTemplateError < Error

--- a/spec/unit/postmark/error_spec.rb
+++ b/spec/unit/postmark/error_spec.rb
@@ -150,6 +150,28 @@ describe(Postmark::MailAdapterError) do
 end
 
 describe(Postmark::InvalidEmailAddressError) do
+  describe '.parse_recipients' do
+    let(:recipient) do
+      "nothing@wildbit.com"
+    end
+
+    subject {Postmark::InvalidEmailAddressError.parse_recipients(message)}
+
+    context '1/1 invalid' do
+      let(:message) do
+        "Error parsing 'To': Illegal email domain '#{recipient.split('@').last}' in address '#{recipient}'."
+      end
+
+      it {is_expected.to eq([recipient])}
+    end
+
+    context 'unknown error format' do
+      let(:message) {recipient}
+
+      it {is_expected.to eq([])}
+    end
+  end
+
   describe '.new' do
     let(:response) {{'Message' => message}}
 


### PR DESCRIPTION
Currently they are only parsed for InactiveRecipientError however nearly the same code can be used for InvalidEmailAddressError's as well. This PR abstracts the code so that it is used for both.
